### PR TITLE
Updates for issues with install page

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -75,7 +75,7 @@ div.announcement p {
 
 <div class="hero-unit announcement">
   <h3>UV-CDAT 2.1 is released!</h3>
-  <p>The UV-CDAT team is pleased to announce the release of UV-CDAT version 2.1.0 (v2.1). Thanks to users and testers, this is a major bug fix release and therefore we strongly recommend users upgrade their UV-CDAT executable to v2.1. Currently for this release, we are providing binary distributions for <a href="http://sourceforge.net/projects/cdat/files/Releases/UV-CDAT/2.1.0/UV-CDAT-2.1.0-CentOS6.5-RedHat6-64bit.tar.gz/download">RedHat6/CentOS6</a>, <a href="http://sourceforge.net/projects/cdat/files/Releases/UV-CDAT/2.1.0/UV-CDAT-2.1.0-Ubuntu-14.XX-64bit.tar.gz/download">Ubuntu 14.XX</a>, <a href="http://sourceforge.net/projects/cdat/files/Releases/UV-CDAT/2.1.0/UV-CDAT-2.1.0-Mac-10.8.tar.gz/download">Mac OS X 10.8</a> and <a href="http://sourceforge.net/projects/cdat/files/Releases/UV-CDAT/2.1.0/UV-CDAT-2.1.0-Mac-10.9.tar.gz/download">up</a>, and the <a href="https://github.com/UV-CDAT/uvcdat/archive/2.1.0.tar.gz">installation source code</a>. Additional binaries may become available later.</p>
+  <p>The UV-CDAT team is pleased to announce the release of UV-CDAT version 2.1.0 (v2.1). Thanks to users and testers, this is a major bug fix release and therefore we strongly recommend users upgrade their UV-CDAT executable to v2.1. Currently for this release, we are providing binary distributions for RedHat6/CentOS6, Ubuntu 14.XX, Mac OS X 10.8 and up, and the installation source code. Additional binaries may become available later. Visit <a href="installing.html">Installing</a> for directions on how to get UVCDAT 2.1.</p>
 </div>
 
 <h2>The UV-CDAT Project</h2>

--- a/content/installing.html
+++ b/content/installing.html
@@ -7,27 +7,28 @@ description: Test description
 {% extends "base.j2" %}
 
 {% block container %}
-### Quick Basics
+### Quick Facts
 * The UV-CDAT application currently available for Linux and Mac (Windows coming soon)
 * Though UV-CDAT will and has been built on many Linux distros we currently only support Ubuntu and RedHat/CentOS
 * [UV-CDAT License <i class="icon icon-globe"></i>](http://www.gnu.org/licenses/gpl.html)
 * [Available Packages in CDAT <i class="icon icon-globe"></i>](https://github.com/UV-CDAT/uvcdat/wiki/What-Is-Built)
 
-### Installing UV-CDAT
+### Install UV-CDAT
 
 <div class="alert">
     <strong>Don't Forget!</strong> <a href="mailto:majordomo@lists.llnl.gov?body=subscribe%20uvcdat-support" target="_self">Register</a> for our support mailing list to get help with anything UV-CDAT related.
 </div>
 
-* [Mac <i class="icon icon-globe"></i>](https://github.com/UV-CDAT/uvcdat/wiki/Install-on-Mac-OS-X)
-* [RedHat/CentOS <i class="icon icon-globe"></i>](https://github.com/UV-CDAT/uvcdat/wiki/installation-on-RedHat---CentOS)
-* [Ubuntu <i class="icon icon-globe"></i>](https://github.com/UV-CDAT/uvcdat/wiki/Install-on-Ubuntu)
+* [Binary Installation Instructions (Recommended)](https://github.com/UV-CDAT/uvcdat/wiki/install)
+* [Build from Source Directions](https://github.com/UV-CDAT/uvcdat/wiki/Build)
 
-### Installation Notes
+<!--
+### Release Information
 * [Release Notes <i class="icon icon-globe"></i>](https://github.com/UV-CDAT/uvcdat/wiki/Roadmap-to-Release)
 * [GitHub Releases <i class="icon icon-globe"></i>](https://github.com/UV-CDAT/uvcdat/releases)
 * [Binaries (UV-CDAT 2.1) <i class="icon icon-globe"></i>](http://sourceforge.net/projects/cdat/files/Releases/UV-CDAT/2.1.0/)
 * [Binaries (UV-CDAT 2.0) <i class="icon icon-globe"></i>](http://sourceforge.net/projects/cdat/files/Releases/UV-CDAT/2.0.0/)
+-->
 
 <!--
 ### Old Install Notes 


### PR DESCRIPTION
Updated install info to point to the new wiki pages, removed the links to the binaries I had in the release note. Also hid some of the extra info from the Install page.